### PR TITLE
Add DialogueMonoSystem skeleton

### DIFF
--- a/Assets/Prefabs/MonoSystems/Dialogue/DialogueMonoSystem.prefab
+++ b/Assets/Prefabs/MonoSystems/Dialogue/DialogueMonoSystem.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2887407841870119093}
+  - component: {fileID: 6603474244123363811}
   m_Layer: 0
   m_Name: DialogueMonoSystem
   m_TagString: Untagged
@@ -29,5 +30,17 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: -1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6603474244123363811
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4551208929398572034}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 778d7001dfe124a11b64d7f898876583, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Resources/GameManager.prefab
+++ b/Assets/Resources/GameManager.prefab
@@ -57,6 +57,7 @@ MonoBehaviour:
   partyMonoSystem: {fileID: 4792072170638144708}
   playerPreferencesMonoSystem: {fileID: 4089780349662454133}
   saveMonoSystem: {fileID: 8527105544289723711}
+  dialogueMonoSystem: {fileID: 7673398307471678892}
 --- !u!1 &3403851422182821397
 GameObject:
   m_ObjectHideFlags: 0
@@ -516,6 +517,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2887407841870119093, guid: d7b8d8b1b0521d3408a4357654e2a2ce, type: 3}
   m_PrefabInstance: {fileID: 3591941538705626191}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &7673398307471678892 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6603474244123363811, guid: d7b8d8b1b0521d3408a4357654e2a2ce, type: 3}
+  m_PrefabInstance: {fileID: 3591941538705626191}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 778d7001dfe124a11b64d7f898876583, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &3856616680452018967
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Runtime/AkashicGameManager.cs
+++ b/Assets/Scripts/Runtime/AkashicGameManager.cs
@@ -1,7 +1,8 @@
 using Akashic.Core;
 using Akashic.Runtime.MonoSystems.BattleStates;
-using Akashic.Runtime.MonoSystems.GameStates;
+using Akashic.Runtime.MonoSystems.Dialogue;
 using Akashic.Runtime.MonoSystems.ExplorationStates;
+using Akashic.Runtime.MonoSystems.GameStates;
 using Akashic.Runtime.MonoSystems.Party;
 using Akashic.Runtime.MonoSystems.PlayerPrefs;
 using Akashic.Runtime.MonoSystems.Save;
@@ -27,6 +28,7 @@ namespace Akashic.Runtime
         [SerializeField] private PartyMonoSystem partyMonoSystem;
         [SerializeField] private PlayerPreferencesMonoSystem playerPreferencesMonoSystem;
         [SerializeField] private SaveMonoSystem saveMonoSystem;
+        [SerializeField] private DialogueMonoSystem dialogueMonoSystem;
 
         protected override string GetApplicationName()
         {
@@ -51,6 +53,7 @@ namespace Akashic.Runtime
             AddMonoSystem<PartyMonoSystem, IPartyMonoSystem>(partyMonoSystem);
             AddMonoSystem<PlayerPreferencesMonoSystem, IPlayerPreferencesMonoSystem>(playerPreferencesMonoSystem);
             AddMonoSystem<SaveMonoSystem, ISaveMonoSystem>(saveMonoSystem);
+            AddMonoSystem<DialogueMonoSystem, IDialogueMonoSystem>(dialogueMonoSystem);
         }
     }
 }

--- a/Assets/Scripts/Runtime/MonoSystems/Dialogue.meta
+++ b/Assets/Scripts/Runtime/MonoSystems/Dialogue.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0d77db5a15d114fe7affcfbab1a5d11d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/MonoSystems/Dialogue/DialogueMonoSystem.cs
+++ b/Assets/Scripts/Runtime/MonoSystems/Dialogue/DialogueMonoSystem.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+using Akashic.Core;
+
+namespace Akashic.Runtime.MonoSystems.Dialogue
+{
+    internal sealed class DialogueMonoSystem : MonoBehaviour, IDialogueMonoSystem
+    {
+    }
+}

--- a/Assets/Scripts/Runtime/MonoSystems/Dialogue/DialogueMonoSystem.cs.meta
+++ b/Assets/Scripts/Runtime/MonoSystems/Dialogue/DialogueMonoSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 778d7001dfe124a11b64d7f898876583
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/MonoSystems/Dialogue/IDialogueMonoSystem.cs
+++ b/Assets/Scripts/Runtime/MonoSystems/Dialogue/IDialogueMonoSystem.cs
@@ -1,0 +1,11 @@
+using Akashic.Core;
+
+namespace Akashic.Runtime.MonoSystems.Dialogue
+{
+    /// <summary>
+    /// Provides dialogue functionality.
+    /// </summary>
+    internal interface IDialogueMonoSystem : IMonoSystem
+    {
+    }
+}

--- a/Assets/Scripts/Runtime/MonoSystems/Dialogue/IDialogueMonoSystem.cs.meta
+++ b/Assets/Scripts/Runtime/MonoSystems/Dialogue/IDialogueMonoSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0725adf675d45441e89c6ffd67bd7637
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation~/CodingStandards.md
+++ b/Documentation~/CodingStandards.md
@@ -274,7 +274,7 @@ When creating a new `MonoSystem`, we must first define an interface for the `Mon
 // All MonoSystems require an interface to be defined.
 //
 // The interface of the MonoSystem resides in a subfolder of the same name within
-// the the "Assets/Runtime/MonoSystems" folder.
+// the "Assets/Runtime/MonoSystems" folder.
 //
 // Defining an interface for our MonoSystem allows for MonoSystems to be generically typed,
 // which enables the bootstrapping of MonoSystems at runtime. Interfaces also allow us


### PR DESCRIPTION
Closes #93 

Overview:

This PR adds `DialogueMonoSystem` and `IDialogueMonoSystem`. It then uses those scripts and a preexisting `DialogueMonoSystem` prefab in the bootstrapping logic of `AkashicGameManager`.

Testing:

I tested this by adding a temporary log message in the `Start()` of `DialogueMonoSystem` script, hitting play in Unity, and checking the console for errors.

Considerations:

While reading through the documentation, I noticed that in `CodingStandards.md` it mentions that `ExampleMonoSystem` should inherit from `IMonoSystem for generic typing during the GameManager bootstrapping routine`. I checked some of the other MonoSystems and it doesn't seem like this is required for bootstrapping to work as intended. If this is required, I'll update this and can update the other MonoSystems to inherit from `IMonoSystem` as well.