### PR TITLE
Add story event ScriptableObject

### DIFF
--- a/Assets/ScriptableObjects/Scripts/StoryEventBaseData.cs
+++ b/Assets/ScriptableObjects/Scripts/StoryEventBaseData.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Akashic.Runtime.MonoSystems.Dialogue;
 
 namespace Akashic.ScriptableObjects.Scripts
 {
@@ -9,13 +9,4 @@ namespace Akashic.ScriptableObjects.Scripts
     {
         public List<StoryPoint> storyPoints;
     }
-}
-
-[Serializable]
-public class StoryPoint
-{
-    public string dialogueLine;
-    public Sprite profilePicture;
-    public Sprite backgroundImage;
-    public AudioSource music;
 }

--- a/Assets/ScriptableObjects/Scripts/StoryEventBaseData.cs
+++ b/Assets/ScriptableObjects/Scripts/StoryEventBaseData.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Akashic.ScriptableObjects.Scripts
+{
+    [CreateAssetMenu(menuName = "Akashic/Story Event/New Base Story Event")]
+    internal sealed class StoryEventBaseData : ScriptableObject
+    {
+        public List<StoryPoint> storyPoints;
+
+        [Serializable]
+        public class StoryPoint
+        {
+            public string dialogueLine;
+
+            public Sprite profilePicture;
+
+            public Sprite backgroundImage;
+
+            public AudioSource music;
+        }
+    }
+}

--- a/Assets/ScriptableObjects/Scripts/StoryEventBaseData.cs
+++ b/Assets/ScriptableObjects/Scripts/StoryEventBaseData.cs
@@ -8,17 +8,14 @@ namespace Akashic.ScriptableObjects.Scripts
     internal sealed class StoryEventBaseData : ScriptableObject
     {
         public List<StoryPoint> storyPoints;
-
-        [Serializable]
-        public class StoryPoint
-        {
-            public string dialogueLine;
-
-            public Sprite profilePicture;
-
-            public Sprite backgroundImage;
-
-            public AudioSource music;
-        }
     }
+}
+
+[Serializable]
+public class StoryPoint
+{
+    public string dialogueLine;
+    public Sprite profilePicture;
+    public Sprite backgroundImage;
+    public AudioSource music;
 }

--- a/Assets/ScriptableObjects/Scripts/StoryEventBaseData.cs.meta
+++ b/Assets/ScriptableObjects/Scripts/StoryEventBaseData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77b1e0403999a4de48de71f968bfb1da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/MonoSystems/Dialogue/StoryPoint.cs
+++ b/Assets/Scripts/Runtime/MonoSystems/Dialogue/StoryPoint.cs
@@ -1,0 +1,14 @@
+using System;
+using UnityEngine;
+
+namespace Akashic.Runtime.MonoSystems.Dialogue
+{
+    [Serializable]
+    internal sealed class StoryPoint
+    {
+        public string dialogueLine;
+        public Sprite profilePicture;
+        public Sprite backgroundImage;
+        public AudioSource music;
+    }
+}

--- a/Assets/Scripts/Runtime/MonoSystems/Dialogue/StoryPoint.cs.meta
+++ b/Assets/Scripts/Runtime/MonoSystems/Dialogue/StoryPoint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcfba2323641741628d63a4b5e6cc9e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Closes #97 

This PR adds a ScriptableObject (SO) for story events. The SO consists of a list of `StoryPoint`s which have the following fields:

* `dialogueLine`
* `profielPicture`
* `backgroundImage`
* `music`

Here's a screenshot of an example in the inspector window:

![Screenshot 2023-08-31 at 12 31 50 PM](https://github.com/yokozach/The-Mechanical-Forest/assets/16309000/213dbf72-dab7-4b5b-b6c0-6be2664dc7c3)
