### PR TITLE
Prevent raycaysting through canvas

### DIFF
--- a/Assets/Scripts/Runtime/MonoSystems/Story/StoryEventInjector.cs
+++ b/Assets/Scripts/Runtime/MonoSystems/Story/StoryEventInjector.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using Akashic.Core;
 using Akashic.ScriptableObjects.Scripts;
+using UnityEngine.EventSystems;
 
 namespace Akashic.Runtime.MonoSystems.Story
 {
@@ -10,6 +11,11 @@ namespace Akashic.Runtime.MonoSystems.Story
 
         private void OnMouseDown()
         {
+            // Block raycast when canvas is up
+            if (EventSystem.current.IsPointerOverGameObject())
+            {
+                return;
+            }
             GameManager.Publish(new DialogueStoryEventMessage(storyEvent));
         }
     }


### PR DESCRIPTION
Closes #106 

This PR adds some logic to `StoryEventInjector.cs` that prevents clicking on the object when the canvas is up.

**Testing**

You can add a debug message to the `OnMouseDown` method of the `StoryEventInjector` script. Then, using `Assets/Scenes/Test/StoryMonoSystem_Test/StoryMonoSystemScene_Test.unity`,  you can click the red box which will open up the dialogue canvas. Finally, try to click on the area of the screen where the red box is (underneath the canvas) and check the console to make sure your debug message isn't printing.