### PR TITLE
Make Fields Private and Use Properties In `PartyMemberController` and Related Classes

### DIFF
--- a/Assets/Scripts/Runtime/Controllers/PartyMemberBattle/PartyMemberController.cs
+++ b/Assets/Scripts/Runtime/Controllers/PartyMemberBattle/PartyMemberController.cs
@@ -8,7 +8,7 @@ namespace Akashic.Runtime.Controllers.PartyMemberBattle
     internal sealed class PartyMemberController : MonoBehaviour
     {
         [Header("Party Member Info")]
-        [SerializeField] public string partyMemberName;
+        [SerializeField] private string partyMemberName;
 
         [Header("Base Data")]
         [SerializeField] private PartyMemberBaseData partyMemberBaseData;
@@ -27,6 +27,8 @@ namespace Akashic.Runtime.Controllers.PartyMemberBattle
         [SerializeField] public PartyMemberEffectHandler partyMemberEffectHandler;
 
         [SerializeField] public PartyMemberSoundHandler partyMemberSoundHandler;
+        
+        public string PartyMemberName => partyMemberName;
 
         public void InitializeNewPartyMemberFromScriptableObject()
         {

--- a/Assets/Scripts/Runtime/Controllers/PartyMemberBattle/PartyMemberController.cs
+++ b/Assets/Scripts/Runtime/Controllers/PartyMemberBattle/PartyMemberController.cs
@@ -9,7 +9,7 @@ namespace Akashic.Runtime.Controllers.PartyMemberBattle
     {
         [Header("Party Member Info")]
         [SerializeField] public string partyMemberName;
-        
+
         [Header("Base Data")]
         [SerializeField] private PartyMemberBaseData partyMemberBaseData;
         

--- a/Assets/Scripts/Runtime/Controllers/PartyMemberBattle/PartyMemberResourceHandler.cs
+++ b/Assets/Scripts/Runtime/Controllers/PartyMemberBattle/PartyMemberResourceHandler.cs
@@ -17,18 +17,18 @@ namespace Akashic.Runtime.Controllers.PartyMemberBattle
         private int maxHealth;
         private int maxExperience;
         
-        public int CurrentHealth { get => currentHealth; private set => currentHealth = value; }
-        public int CurrentExperience { get => currentExperience; private set => currentExperience = value; }
-        
-        public int MaxHealth { get => maxHealth; }
-        public int MaxExperience { get => maxExperience; }
-        
+        public int CurrentHealth => currentHealth;
+        public int CurrentExperience => currentExperience;
+
+        public int MaxHealth => maxHealth;
+        public int MaxExperience => maxExperience;
+
         public void InitializeNewPartyMemberFromScriptableObject(PartyMemberBaseData baseData)
         {
             currentHealth = baseData.baseHealth;
-            maxHealth = baseData.baseHealth;
-
             currentExperience = baseData.baseExp;
+            
+            maxHealth = baseData.baseHealth;
         }
     }
 }

--- a/Assets/Scripts/Runtime/Controllers/PartyMemberBattle/PartyMemberResourceHandler.cs
+++ b/Assets/Scripts/Runtime/Controllers/PartyMemberBattle/PartyMemberResourceHandler.cs
@@ -10,12 +10,18 @@ namespace Akashic.Runtime.Controllers.PartyMemberBattle
         [SerializeField] private PartyMemberController partyMemberController;
         
         [Header("Resources")]
-        [SerializeField] public int currentHealth;
+        [SerializeField] private int currentHealth;
 
-        [SerializeField] public int currentExperience;
+        [SerializeField] private int currentExperience;
 
-        public int maxHealth;
-        public int maxExperience;
+        private int maxHealth;
+        private int maxExperience;
+        
+        public int CurrentHealth { get => currentHealth; private set => currentHealth = value; }
+        public int CurrentExperience { get => currentExperience; private set => currentExperience = value; }
+        
+        public int MaxHealth { get => maxHealth; }
+        public int MaxExperience { get => maxExperience; }
         
         public void InitializeNewPartyMemberFromScriptableObject(PartyMemberBaseData baseData)
         {

--- a/Assets/Scripts/Runtime/Controllers/PartyMemberBattle/PartyMemberStatHandler.cs
+++ b/Assets/Scripts/Runtime/Controllers/PartyMemberBattle/PartyMemberStatHandler.cs
@@ -28,22 +28,22 @@ namespace Akashic.Runtime.Controllers.PartyMemberBattle
         [SerializeField] private int baseMagicalDefense;
         [SerializeField] private float baseEvade;
         
-        public int CurrentLevel { get => currentLevel; private set => currentLevel = value; }
-        public int CurrentPhysicalAttack { get => currentPhysicalAttack; private set => currentPhysicalAttack = value; }
-        public int CurrentMagicalAttack { get => currentMagicalAttack; private set => currentMagicalAttack = value; }
-        public float CurrentAccuracy { get => currentAccuracy; private set => currentAccuracy = value; }
-        
-        public int CurrentPhysicalDefense { get => currentPhysicalDefense; private set => currentPhysicalDefense = value; }
-        public int CurrentMagicalDefense { get => currentMagicalDefense; private set => currentMagicalDefense = value; }
-        public float CurrentEvade { get => currentEvade; private set => currentEvade = value; }
-        
-        public int BasePhysicalAttack { get => basePhysicalAttack; }
-        public int BaseMagicalAttack { get => baseMagicalAttack; }
-        public float BaseAccuracy { get => baseAccuracy; }
-        
-        public int BasePhysicalDefense { get => basePhysicalDefense; }
-        public int BaseMagicalDefense { get => baseMagicalDefense; }
-        public float BaseEvade { get => baseEvade; }
+        public int CurrentLevel => currentLevel;
+        public int CurrentPhysicalAttack => currentPhysicalAttack;
+        public int CurrentMagicalAttack => currentMagicalAttack;
+        public float CurrentAccuracy => currentAccuracy;
+
+        public int CurrentPhysicalDefense => currentPhysicalDefense;
+        public int CurrentMagicalDefense => currentMagicalDefense;
+        public float CurrentEvade => currentEvade;
+
+        public int BasePhysicalAttack => basePhysicalAttack;
+        public int BaseMagicalAttack => baseMagicalAttack;
+        public float BaseAccuracy => baseAccuracy;
+
+        public int BasePhysicalDefense => basePhysicalDefense;
+        public int BaseMagicalDefense => baseMagicalDefense;
+        public float BaseEvade => baseEvade;
 
         public void InitializeNewPartyMemberFromScriptableObject(PartyMemberBaseData baseData)
         {

--- a/Assets/Scripts/Runtime/Controllers/PartyMemberBattle/PartyMemberStatHandler.cs
+++ b/Assets/Scripts/Runtime/Controllers/PartyMemberBattle/PartyMemberStatHandler.cs
@@ -10,26 +10,45 @@ namespace Akashic.Runtime.Controllers.PartyMemberBattle
         [SerializeField] private PartyMemberController partyMemberController;
         
         [Header("Stats")]
-        [SerializeField] public int currentLevel;
+        [SerializeField] private int currentLevel;
         
-        [SerializeField] public int currentPhysicalAttack;
-        [SerializeField] public int currentMagicalAttack;
-        [SerializeField] public float currentAccuracy;
+        [SerializeField] private int currentPhysicalAttack;
+        [SerializeField] private int currentMagicalAttack;
+        [SerializeField] private float currentAccuracy;
         
-        [SerializeField] public int currentPhysicalDefense;
-        [SerializeField] public int currentMagicalDefense;
-        [SerializeField] public float currentEvade;
+        [SerializeField] private int currentPhysicalDefense;
+        [SerializeField] private int currentMagicalDefense;
+        [SerializeField] private float currentEvade;
         
-        public int basePhysicalAttack;
-        public int baseMagicalAttack;
-        public float baseAccuracy;
+        [SerializeField] private int basePhysicalAttack;
+        [SerializeField] private int baseMagicalAttack;
+        [SerializeField] private float baseAccuracy;
         
-        public int basePhysicalDefense;
-        public int baseMagicalDefense;
-        public float baseEvade;
+        [SerializeField] private int basePhysicalDefense;
+        [SerializeField] private int baseMagicalDefense;
+        [SerializeField] private float baseEvade;
         
+        public int CurrentLevel { get => currentLevel; private set => currentLevel = value; }
+        public int CurrentPhysicalAttack { get => currentPhysicalAttack; private set => currentPhysicalAttack = value; }
+        public int CurrentMagicalAttack { get => currentMagicalAttack; private set => currentMagicalAttack = value; }
+        public float CurrentAccuracy { get => currentAccuracy; private set => currentAccuracy = value; }
+        
+        public int CurrentPhysicalDefense { get => currentPhysicalDefense; private set => currentPhysicalDefense = value; }
+        public int CurrentMagicalDefense { get => currentMagicalDefense; private set => currentMagicalDefense = value; }
+        public float CurrentEvade { get => currentEvade; private set => currentEvade = value; }
+        
+        public int BasePhysicalAttack { get => basePhysicalAttack; }
+        public int BaseMagicalAttack { get => baseMagicalAttack; }
+        public float BaseAccuracy { get => baseAccuracy; }
+        
+        public int BasePhysicalDefense { get => basePhysicalDefense; }
+        public int BaseMagicalDefense { get => baseMagicalDefense; }
+        public float BaseEvade { get => baseEvade; }
+
         public void InitializeNewPartyMemberFromScriptableObject(PartyMemberBaseData baseData)
         {
+            currentLevel = baseData.baseLevel;
+            
             basePhysicalAttack = baseData.basePhysicalAttack;
             baseMagicalAttack = baseData.baseMagicalAttack;
             baseAccuracy = baseData.baseAccuracy;
@@ -37,13 +56,19 @@ namespace Akashic.Runtime.Controllers.PartyMemberBattle
             basePhysicalDefense = baseData.basePhysicalDefense;
             baseMagicalDefense = baseData.baseMagicalDefense;
             baseEvade = baseData.baseEvade;
-            
-            CalculateCurrentStats();
+                
+            ResetCurrentStatsToBase();
         }
 
-        private void CalculateCurrentStats()
+        private void ResetCurrentStatsToBase()
         {
+            currentPhysicalAttack = basePhysicalAttack;
+            currentMagicalAttack = baseMagicalAttack;
+            currentAccuracy = baseAccuracy;
             
+            currentPhysicalDefense = basePhysicalDefense;
+            currentMagicalDefense = baseMagicalDefense;
+            currentEvade = baseEvade;
         }
     }
 }

--- a/Assets/Scripts/Runtime/Converters/PartyMemberConverter.cs
+++ b/Assets/Scripts/Runtime/Converters/PartyMemberConverter.cs
@@ -9,17 +9,17 @@ namespace Akashic.Runtime.Converters
         {
             var partyMember = new PartyMember(
                 partyMemberController.partyMemberName,
-                partyMemberController.partyMemberStatHandler.currentLevel,
-                partyMemberController.partyMemberResourceHandler.currentExperience,
-                partyMemberController.partyMemberResourceHandler.maxExperience,
-                partyMemberController.partyMemberResourceHandler.currentHealth,
-                partyMemberController.partyMemberResourceHandler.maxHealth,
-                partyMemberController.partyMemberStatHandler.basePhysicalAttack,
-                partyMemberController.partyMemberStatHandler.baseMagicalAttack,
-                partyMemberController.partyMemberStatHandler.baseAccuracy,
-                partyMemberController.partyMemberStatHandler.basePhysicalDefense,
-                partyMemberController.partyMemberStatHandler.baseMagicalDefense,
-                partyMemberController.partyMemberStatHandler.baseEvade
+                partyMemberController.partyMemberStatHandler.CurrentLevel,
+                partyMemberController.partyMemberResourceHandler.CurrentExperience,
+                partyMemberController.partyMemberResourceHandler.MaxExperience,
+                partyMemberController.partyMemberResourceHandler.CurrentHealth,
+                partyMemberController.partyMemberResourceHandler.MaxHealth,
+                partyMemberController.partyMemberStatHandler.BasePhysicalAttack,
+                partyMemberController.partyMemberStatHandler.BaseMagicalAttack,
+                partyMemberController.partyMemberStatHandler.BaseAccuracy,
+                partyMemberController.partyMemberStatHandler.BasePhysicalDefense,
+                partyMemberController.partyMemberStatHandler.BaseMagicalDefense,
+                partyMemberController.partyMemberStatHandler.BaseEvade
                 );
 
             return partyMember;

--- a/Assets/Scripts/Runtime/Converters/PartyMemberConverter.cs
+++ b/Assets/Scripts/Runtime/Converters/PartyMemberConverter.cs
@@ -8,7 +8,7 @@ namespace Akashic.Runtime.Converters
         public static PartyMember ConvertControllerToPartyMember(PartyMemberController partyMemberController)
         {
             var partyMember = new PartyMember(
-                partyMemberController.partyMemberName,
+                partyMemberController.PartyMemberName,
                 partyMemberController.partyMemberStatHandler.CurrentLevel,
                 partyMemberController.partyMemberResourceHandler.CurrentExperience,
                 partyMemberController.partyMemberResourceHandler.MaxExperience,


### PR DESCRIPTION
**Changes:**
- `PartyMemberController`, `PartyMemberStatHandler`, and `PartyMemberResourceHandler` `fields` are now `private`, and the values of these `fields` are now privately set. Accessing the values of these `fields` is done through `properties`, which prevents unintentional modification of these values by external scripts.

**For More Info See:**
closes #116