### PR TITLE
Add story point progression

### DIFF
--- a/Assets/Resources/GameManager.prefab
+++ b/Assets/Resources/GameManager.prefab
@@ -1014,6 +1014,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -13.67
       objectReference: {fileID: 0}
+    - target: {fileID: 887609714318162357, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2437112949521479818, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3578013923362603765, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3695396507953499012, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
@@ -1057,6 +1069,10 @@ PrefabInstance:
     - target: {fileID: 3792497209622191639, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -60.210003
+      objectReference: {fileID: 0}
+    - target: {fileID: 3809380105944975619, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3866557529868466862, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1158,6 +1174,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -8.69565
       objectReference: {fileID: 0}
+    - target: {fileID: 5587624460984190414, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6061790245413834108, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
@@ -1205,6 +1225,10 @@ PrefabInstance:
     - target: {fileID: 6923344453337361479, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -22.87
+      objectReference: {fileID: 0}
+    - target: {fileID: 7391907385788788762, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
+      propertyPath: m_Alpha
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7391907385788788762, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
       propertyPath: m_BlocksRaycasts
@@ -1353,6 +1377,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 887609714318162357, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
       insertIndex: -1
       addedObject: {fileID: 5530280257766518422}
+    - targetCorrespondingSourceObject: {fileID: 887609714318162357, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7915971020319015756}
   m_SourcePrefab: {fileID: 100100000, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}
 --- !u!225 &1664513336614906561 stripped
 CanvasGroup:
@@ -1379,6 +1406,51 @@ MonoBehaviour:
   canvasGroup: {fileID: 1664513336614906561}
   nameText: {fileID: 5731062770925400145}
   dialogueText: {fileID: 6252576990400695712}
+--- !u!61 &7915971020319015756
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3815330775094389879}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!4 &4730691249935430298 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8720483823637260120, guid: 4156161d05bc3104ea805347006b3dd2, type: 3}

--- a/Assets/Scenes/Test/StoryMonoSystem_Test/StoryMonoSystemScene_Test.unity
+++ b/Assets/Scenes/Test/StoryMonoSystem_Test/StoryMonoSystemScene_Test.unity
@@ -271,6 +271,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5972398923102618262, guid: ce7ba7d2391c4b04dbfd36ebd939c4c3, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Scripts/Runtime/Controllers/Story/DialoguePanel.cs
+++ b/Assets/Scripts/Runtime/Controllers/Story/DialoguePanel.cs
@@ -1,15 +1,19 @@
 using Akashic.Runtime.Common;
 using Akashic.Runtime.MonoSystems.Story;
+using System;
 using TMPro;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 namespace Akashic.Runtime.Controllers.Story
 {
-    internal sealed class DialoguePanel : OverlayController
+    internal sealed class DialoguePanel : OverlayController, IPointerClickHandler
     {
         [Header("UI Elements")]
         [SerializeField] private TextMeshProUGUI nameText;
         [SerializeField] private TextMeshProUGUI dialogueText;
+
+        public event EventHandler OnDialoguePanelClicked;
 
         public override void Hide()
         {
@@ -32,6 +36,11 @@ namespace Akashic.Runtime.Controllers.Story
         private void SetDialogue(string dialogue)
         {
             dialogueText.text = dialogue;
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            OnDialoguePanelClicked?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/Assets/Scripts/Runtime/Controllers/Story/StoryController.cs
+++ b/Assets/Scripts/Runtime/Controllers/Story/StoryController.cs
@@ -2,6 +2,7 @@ using Akashic.Core;
 using UnityEngine;
 using Akashic.Runtime.Common;
 using Akashic.Runtime.MonoSystems.Story;
+using System;
 
 namespace Akashic.Runtime.Controllers.Story
 {
@@ -48,14 +49,29 @@ namespace Akashic.Runtime.Controllers.Story
             ShowStoryPointDialogue(currentStoryPoint);
         }
 
+        private void OnStoryEventEndedMessage(StoryEventEndedMessage message)
+        {
+            Hide();
+            dialoguePanel.Hide();
+        }
+
+        private void ProgressDialogue(object sender, EventArgs e)
+        {
+            storyMonoSystem.AdvanceStoryPoint();
+        }
+
         private void AddListeners()
         {
             GameManager.AddListener<StoryEventAvailableMessage>(OnStoryEventAvailableMessage);
+            GameManager.AddListener<StoryEventEndedMessage>(OnStoryEventEndedMessage);
+            dialoguePanel.OnDialoguePanelClicked += ProgressDialogue;
         }
 
         private void RemoveListeners()
         {
             GameManager.RemoveListener<StoryEventAvailableMessage>(OnStoryEventAvailableMessage);
+            GameManager.RemoveListener<StoryEventEndedMessage>(OnStoryEventEndedMessage);
+            dialoguePanel.OnDialoguePanelClicked -= ProgressDialogue;
         }
     }
 }

--- a/Assets/Scripts/Runtime/MonoSystems/Story/IStoryMonoSystem.cs
+++ b/Assets/Scripts/Runtime/MonoSystems/Story/IStoryMonoSystem.cs
@@ -5,5 +5,6 @@ namespace Akashic.Runtime.MonoSystems.Story
     internal interface IStoryMonoSystem : IMonoSystem
     {
         public StoryPoint GetCurrentStoryPoint();
+        public void AdvanceStoryPoint();
     }
 }

--- a/Assets/Scripts/Runtime/MonoSystems/Story/StoryMonoSystem.cs
+++ b/Assets/Scripts/Runtime/MonoSystems/Story/StoryMonoSystem.cs
@@ -28,22 +28,28 @@ namespace Akashic.Runtime.MonoSystems.Story
                 throw new Exception($"{currentStoryEvent} cannot be null or empty.");
             }
 
-            var tempStoryPoint = currentStoryEvent.storyPoints[storyPointIndex++];
-
-            HasStoryEventEnded();
-
-            return tempStoryPoint;
+            return currentStoryEvent.storyPoints[storyPointIndex];
         }
 
-        private void HasStoryEventEnded()
+        public void AdvanceStoryPoint()
+        {
+            storyPointIndex++;
+            if (HasStoryEventEnded() == false)
+            {
+                GameManager.Publish(new StoryEventAvailableMessage());
+            };
+        }
+
+        private bool HasStoryEventEnded()
         {
             if (storyPointIndex >= currentStoryEvent.storyPoints.Count)
             {
                 currentStoryEvent = new StoryEvent(new List<StoryPoint>());
                 storyPointIndex = 0;
+                GameManager.Publish(new StoryEventEndedMessage());
+                return true;
             }
-
-            GameManager.Publish(new StoryEventEndedMessage());
+            return false;
         }
 
         private void OnNewStoryEventMessage(NewStoryEventMessage message)


### PR DESCRIPTION
Closes #146 

This PR adds the ability to click through lines of dialogue during a story event by progressing through each story point when clicked until ultimately resetting and hiding the canvas.

**Testing**

Load up the test scene `Assets/Scenes/Test/StoryMonoSystem_Test/StoryMonoSystemScene_Test.unity` and click the red box. Then, click through the two separate lines of dialogue that should have different character names. Finally, make sure the scene returns to normal, displaying the red box again.

**Considerations**

I tried to follow this outline:

![image](https://github.com/yokozach/The-Mechanical-Forest/assets/16309000/25d454b4-15b6-4c6b-b201-11d0c2c33b6a)

I used a C# event/action to communicate between the dialogue panel and the controller and used the message bus and a direct reference at times to communicate between the controller and the monosystem, following the architecture we had laid out during previous work.

I ended up refactoring the `StoryMonoSystem.GetCurrentStoryPoint()` and `StoryMonoSystem.HasStoryEventEnded()` methods a bit by introducing a third method called `StoryMonoSystem.AdvanceStoryPoint()` in order to separate functionality a little more clearly. Before the refactor, the `StoryPointIndex` could exceed the number of story points in the story event and the code I wrote to fix that within the original method made everything feel kinda messy.