### PR TITLE
Updated SO and SOs instances to include ItemId and itemDisplayName 

### DIFF
--- a/Assets/Resources/Items/Accessories/BraceletBaseData.asset
+++ b/Assets/Resources/Items/Accessories/BraceletBaseData.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1026fd2480ace184aba8e2cab2543014, type: 3}
   m_Name: BraceletBaseData
   m_EditorClassIdentifier: 
-  itemName: Bracelet
+  itemId: bracelet
+  itemDisplayName: Bracelet
   description: 
   icon: {fileID: 0}

--- a/Assets/Resources/Items/Accessories/EaringsBaseData.asset
+++ b/Assets/Resources/Items/Accessories/EaringsBaseData.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1026fd2480ace184aba8e2cab2543014, type: 3}
   m_Name: EaringsBaseData
   m_EditorClassIdentifier: 
-  itemName: Earings
+  itemId: earings
+  itemDisplayName: Earings
   description: 
   icon: {fileID: 0}

--- a/Assets/Resources/Items/Accessories/NecklaceBaseData.asset
+++ b/Assets/Resources/Items/Accessories/NecklaceBaseData.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1026fd2480ace184aba8e2cab2543014, type: 3}
   m_Name: NecklaceBaseData
   m_EditorClassIdentifier: 
-  itemName: Necklace
+  itemId: necklace
+  itemDisplayName: Necklace
   description: 
   icon: {fileID: 0}

--- a/Assets/Resources/Items/BattleItems/GreenHerbBaseData.asset
+++ b/Assets/Resources/Items/BattleItems/GreenHerbBaseData.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1cea429feed461646a36a0e817165022, type: 3}
   m_Name: GreenHerbBaseData
   m_EditorClassIdentifier: 
-  itemName: Green Herb
+  itemId: greenherb
+  itemDisplayName: Green Herb
   description: Heals 30% of the member's total HP.
   icon: {fileID: 0}

--- a/Assets/Resources/Items/BattleItems/SmellingSaltBaseData.asset
+++ b/Assets/Resources/Items/BattleItems/SmellingSaltBaseData.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1cea429feed461646a36a0e817165022, type: 3}
   m_Name: SmellingSaltBaseData
   m_EditorClassIdentifier: 
-  itemName: Smelling Salt
+  itemId: smellingsalt
+  itemDisplayName: Smelling Salt
   description: Revives a knocked-out ally upon use.
   icon: {fileID: 0}

--- a/Assets/Resources/Items/BattleItems/SweetDewBaseData.asset
+++ b/Assets/Resources/Items/BattleItems/SweetDewBaseData.asset
@@ -12,7 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1cea429feed461646a36a0e817165022, type: 3}
   m_Name: SweetDewBaseData
   m_EditorClassIdentifier: 
-  itemName: Sweet Dew
+  itemId: sweetdew
+  itemDisplayName: Sweet Dew
   description: Reduces AP cost for all skills for the entire party for the first
     turn by half.
   icon: {fileID: 0}

--- a/Assets/Resources/Items/BattleItems/WardingBellBaseData.asset
+++ b/Assets/Resources/Items/BattleItems/WardingBellBaseData.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1cea429feed461646a36a0e817165022, type: 3}
   m_Name: WardingBellBaseData
   m_EditorClassIdentifier: 
-  itemName: Warding Bell
+  itemId: wardingbell
+  itemDisplayName: Warding Bell
   description: Reduces encounters for up to three minutes while exploring.
   icon: {fileID: 0}

--- a/Assets/Resources/Items/Relics/CrystalizedFourLeafCloverBaseData.asset
+++ b/Assets/Resources/Items/Relics/CrystalizedFourLeafCloverBaseData.asset
@@ -12,7 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f253ba66096e95d4a8e751c955a8078a, type: 3}
   m_Name: CrystalizedFourLeafCloverBaseData
   m_EditorClassIdentifier: 
-  itemName: Crystalized Four Leaf Clover
+  itemId: crystalizedfourleafclover
+  itemDisplayName: Crystalized Four Leaf Clover
   description: Has the chance 25% to decrease the AP of one of the abilities of the
     character equiping this by 1 or 2 AP.
   icon: {fileID: 0}

--- a/Assets/Resources/Items/Relics/GoldenSpoonBaseData.asset
+++ b/Assets/Resources/Items/Relics/GoldenSpoonBaseData.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f253ba66096e95d4a8e751c955a8078a, type: 3}
   m_Name: GoldenSpoonBaseData
   m_EditorClassIdentifier: 
-  itemName: Golden Spoon
+  itemId: goldenspoon
+  itemDisplayName: Golden Spoon
   description: Healing output is increased by 5%.
   icon: {fileID: 0}

--- a/Assets/Resources/Items/Relics/InvisibleHandBuzzerBaseData.asset
+++ b/Assets/Resources/Items/Relics/InvisibleHandBuzzerBaseData.asset
@@ -12,7 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f253ba66096e95d4a8e751c955a8078a, type: 3}
   m_Name: InvisibleHandBuzzerBaseData
   m_EditorClassIdentifier: 
-  itemName: Invisible Hand Buzzer
+  itemId: invisiblehandbuzzer
+  itemDisplayName: Invisible Hand Buzzer
   description: On hit of the attack ability of the attacking character, theres a
     5% to inflict an attack down debuff.
   icon: {fileID: 0}

--- a/Assets/Resources/Items/Relics/StoneFeatherBaseData.asset
+++ b/Assets/Resources/Items/Relics/StoneFeatherBaseData.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f253ba66096e95d4a8e751c955a8078a, type: 3}
   m_Name: StoneFeatherBaseData
   m_EditorClassIdentifier: 
-  itemName: Stone Feather
+  itemId: stonefeather
+  itemDisplayName: Stone Feather
   description: Increase Accuracy by 10% but decreases evade by 10%.
   icon: {fileID: 0}

--- a/Assets/ScriptableObjects/ItemBase/AccessoryBaseData.cs
+++ b/Assets/ScriptableObjects/ItemBase/AccessoryBaseData.cs
@@ -5,7 +5,8 @@ namespace Akashic.Assets.ScriptableObjects.ItemBase
 	[CreateAssetMenu(menuName = "Akashic/Items/New Base Accessory")]
 	internal sealed class AccessoryBaseData : ScriptableObject
 	{
-		public string itemName;
+		public string itemId;
+		public string itemDisplayName;
 		public string description;
 		public Sprite icon;
 	}

--- a/Assets/ScriptableObjects/ItemBase/BattleItemBaseData.cs
+++ b/Assets/ScriptableObjects/ItemBase/BattleItemBaseData.cs
@@ -5,7 +5,8 @@ namespace Akashic.Assets.ScriptableObjects.ItemBase
 	[CreateAssetMenu(menuName = "Akashic/Items/New Base Battle Item")]
 	internal sealed class BattleItemBaseData : ScriptableObject
 	{
-		public string itemName;
+		public string itemId;
+		public string itemDisplayName;
 		public string description;
 		public Sprite icon;
 	}

--- a/Assets/ScriptableObjects/ItemBase/RelicBaseData.cs
+++ b/Assets/ScriptableObjects/ItemBase/RelicBaseData.cs
@@ -5,7 +5,8 @@ namespace Akashic.Assets.ScriptableObjects.ItemBase
 	[CreateAssetMenu(menuName = "Akashic/Items/New Base Relic")]
 	internal sealed class RelicBaseData : ScriptableObject
 	{
-		public string itemName;
+		public string itemId;
+		public string itemDisplayName;
 		public string description;
 		public Sprite icon;
 	}


### PR DESCRIPTION
Updated ItemBase/AccessoryBaseData to include a itemId and itemDisplayName instead of itemName
Updated ItemBase/RelicBaseData to include a itemId and itemDisplayName instead of itemName
Updated ItemBase/BattleItemBaseData  to include a itemId and itemDisplayName instead of itemName

Updated all SOs instances to manage the new itemId and itemDisplayName fields

itemId : name of item without spaces and capital letters
itemDisplayName : name of item

closes #162
closes #164 